### PR TITLE
Add back macOS support by bundling for CEF

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,4 +1,4 @@
-led-wall-server
+led-wall-server*
 obj
 cef
 cef-cache

--- a/server/Makefile
+++ b/server/Makefile
@@ -24,6 +24,7 @@ INCFLAGS = $(addprefix -I,$(LOCAL_INC_DIRS)) \
 	`pkg-config --cflags libavcodec`\
 	`pkg-config --cflags libavutil`\
 	`pkg-config --cflags libswscale`\
+	-Icef -Icef/include
   
 
 LDFLAGS = `pkg-config --libs opencv4` \
@@ -34,23 +35,24 @@ LDFLAGS = `pkg-config --libs opencv4` \
 	`pkg-config --libs libavutil`\
 	`pkg-config --libs libswscale`
 
-ifeq ($(shell uname), Linux) # Only link CEF on Linux for now. To support macOS, the program would need to bundled as a .app bundle which is a pain (https://chromiumembedded.github.io/cef/general_usage.html#macos). We should switch to CMake at some point to make this easier.
+ifeq ($(shell uname), Darwin)
+	LDFLAGS += -Fcef/lib -framework 'Chromium Embedded Framework' cef/lib/libcef_dll_wrapper.a
+else
 	LDFLAGS += -Wl,-rpath=cef/lib -Lcef/lib -lcef cef/lib/libcef_dll_wrapper.a
-	INCFLAGS += -Icef -Icef/include
-	CPPFLAGS += -DWITH_CEF
 endif
 
 .PHONY: all
 all: cef/.success led-wall-server
 
 cef/.success:
-ifeq ($(shell uname), Linux)
 	./scripts/get-cef.bash
-endif
 	@touch cef/.success # Create .success file to indicate that script was run successfully
 
 led-wall-server: $(OBJS)
 	$(CXX) $^ -o $@ $(INCFLAGS) $(LDFLAGS)
+ifeq ($(shell uname), Darwin)
+	./scripts/make-macos-bundle.bash
+endif
 
 $(OBJ_DIR)/%.cpp.o: %.cpp $(INCS) | $(OBJ_DIR)
 	mkdir -p $(dir $@)
@@ -61,4 +63,4 @@ $(OBJ_DIR):
 
 .PHONY: clean
 clean:
-	rm -rf $(OBJ_DIR) cef led-wall-server
+	rm -rf $(OBJ_DIR) cef led-wall-server*

--- a/server/scripts/make-macos-bundle.bash
+++ b/server/scripts/make-macos-bundle.bash
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function check_result() {
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+}
+
+if [ ! -f led-wall-server ] || [ -L led-wall-server ]; then
+    echo "Error: led-wall-server executable not found or is a symlink. Please build the project first."
+    exit 1
+fi
+
+mkdir -p 'led-wall-server.app/Contents/MacOS' 'led-wall-server.app/Contents/Frameworks'
+
+# Executable
+
+mv led-wall-server led-wall-server.app/Contents/MacOS/
+ln -sF 'led-wall-server.app/Contents/MacOS/led-wall-server' 'led-wall-server'
+
+# CEF Framework
+
+cp -R 'cef/lib/Chromium Embedded Framework.framework' 'led-wall-server.app/Contents/Frameworks'
+check_result
+
+# CEF Helper
+
+cd cef
+mkdir -p 'led-wall-server Helper.app/Contents/MacOS'
+
+if [ ! -f process_helper_mac.cc ]; then
+    echo "Downloading process_helper_mac.cc..."
+    wget https://github.com/chromiumembedded/cef/raw/refs/heads/master/tests/cefsimple/process_helper_mac.cc
+    check_result
+fi
+
+g++ -std=c++20 -Iinclude -I. process_helper_mac.cc -o 'led-wall-server Helper.app/Contents/MacOS/led-wall-server Helper' -Flib -framework 'Chromium Embedded Framework' lib/libcef_dll_wrapper.a -DCEF_USE_SANDBOX
+check_result
+
+install_name_tool -change '@executable_path/../Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework' '@executable_path/../../../Chromium Embedded Framework.framework/Chromium Embedded Framework' 'led-wall-server Helper.app/Contents/MacOS/led-wall-server Helper'
+check_result
+
+cp -r 'led-wall-server Helper.app' '../led-wall-server.app/Contents/Frameworks'
+check_result
+


### PR DESCRIPTION
Added script to bundle the server executable into a .app bundle as required by CEF (see https://chromiumembedded.github.io/cef/general_usage.html#macos). 

This is not a great way to do this, but it doesn't really matter since macOS is not a production target. Just something quick to make server development work on macOS possible again